### PR TITLE
Added minio API function, removed ENV variables

### DIFF
--- a/docker/go/src/cloud/benchflow/commons/docker/docker.go
+++ b/docker/go/src/cloud/benchflow/commons/docker/docker.go
@@ -15,16 +15,3 @@ func CreateDockerClient() docker.Client {
 		}
 	return *client
 	}
-
-func CreateDockerTLSClient() docker.Client {
-	path := os.Getenv("DOCKER_CERT_PATH")
-	endpoint := "tcp://"+os.Getenv("DOCKER_HOST")+":"+os.Getenv("DOCKER_PORT")
-    ca := fmt.Sprintf("%s/ca.pem", path)
-    cert := fmt.Sprintf("%s/cert.pem", path)
-    key := fmt.Sprintf("%s/key.pem", path)
-    client, err := docker.NewTLSClient(endpoint, cert, key, ca)
-	if err != nil {
-		log.Fatal(err)
-		}
-	return *client
-	}

--- a/kafka/go/src/cloud/benchflow/commons/kafka/kafka.go
+++ b/kafka/go/src/cloud/benchflow/commons/kafka/kafka.go
@@ -10,22 +10,21 @@ import (
 )
 
 type KafkaMessage struct {
-	SUT_name string `json:"SUT_name"`
-	SUT_version string `json:"SUT_version"`
 	Minio_key string `json:"minio_key"`
 	Trial_id string `json:"trial_id"`
 	Experiment_id string `json:"experiment_id"`
-	Total_trials_num int `json:"total_trials_num"`
+	Container_id string `json:"container_id"`
+	Host_id string `json:"host_id"`
+	Collector_name string `json:"collector_name"`
 	}
 
-func signalOnKafka(minioKey string, SUTName string, SUTVersion string, totalTrials int, trialId string, experimentId string, collectorName string) {
-	kafkaMsg := KafkaMessage{SUT_name: SUTName, SUT_version: SUTVersion, Minio_key: minioKey, Trial_id: trialId, Experiment_id: experimentId, Total_trials_num: totalTrials}
+func signalOnKafka(minioKey string, trialID string, experimentID string, containerID string, hostID string, collectorName string, kafkaHost string, kafkaTopic) {
+	kafkaMsg := KafkaMessage{Minio_key: minioKey, Trial_id: trialID, Experiment_id: experimentID, Container_id: containerID, Collector_name: collectorName}
 	jsMessage, err := json.Marshal(kafkaMsg)
 	if err != nil {
 		log.Printf("Failed to marshall json message")
 		}
-	//TODO: the kafka host should be passed as an environment variable
-	producer, err := sarama.NewSyncProducer([]string{os.Getenv("KAFKA_HOST")+":9092"}, nil)
+	producer, err := sarama.NewSyncProducer([]string{kafkaHost+":9092"}, nil)
 	if err != nil {
 	    log.Fatalln(err)
 	}
@@ -34,7 +33,7 @@ func signalOnKafka(minioKey string, SUTName string, SUTVersion string, totalTria
 	        log.Fatalln(err)
 	    }
 	}()
-	msg := &sarama.ProducerMessage{Topic: collectorName, Value: sarama.StringEncoder(jsMessage)}
+	msg := &sarama.ProducerMessage{Topic: kafkaTopic, Value: sarama.StringEncoder(jsMessage)}
 	partition, offset, err := producer.SendMessage(msg)
 	if err != nil {
 	    log.Printf("FAILED to send message: %s\n", err)

--- a/kafka/go/src/cloud/benchflow/commons/kafka/kafka.go
+++ b/kafka/go/src/cloud/benchflow/commons/kafka/kafka.go
@@ -18,13 +18,13 @@ type KafkaMessage struct {
 	Collector_name string `json:"collector_name"`
 	}
 
-func signalOnKafka(minioKey string, trialID string, experimentID string, containerID string, hostID string, collectorName string, kafkaHost string, kafkaTopic) {
+func signalOnKafka(minioKey string, trialID string, experimentID string, containerID string, hostID string, collectorName string, kafkaHost string, kafkaPort string, kafkaTopic) {
 	kafkaMsg := KafkaMessage{Minio_key: minioKey, Trial_id: trialID, Experiment_id: experimentID, Container_id: containerID, Collector_name: collectorName}
 	jsMessage, err := json.Marshal(kafkaMsg)
 	if err != nil {
 		log.Printf("Failed to marshall json message")
 		}
-	producer, err := sarama.NewSyncProducer([]string{kafkaHost+":9092"}, nil)
+	producer, err := sarama.NewSyncProducer([]string{kafkaHost+":"+kafkaPort}, nil)
 	if err != nil {
 	    log.Fatalln(err)
 	}

--- a/minio/go/src/cloud/benchflow/commons/minio/minio.go
+++ b/minio/go/src/cloud/benchflow/commons/minio/minio.go
@@ -31,17 +31,18 @@ func callMinioClient(fileName string, minioHost string, minioKey string) {
 		fmt.Println("Result: " + out.String())
 }
 
-func sendToMinio(fileName string, minioHost string, minioKey string, accessKey string, secretAccessKey string) {
+func sendToMinio(fileName string, minioHost string, minioKey string, accessKey string, secretAccessKey string, fileType string) error {
 	minioClient, err := minio.New(minioHost, accessKey, secretAccessKey, true)
 	if err != nil {
 		fmt.Println(err)
-	    return
+	    return err
 	    }
-	_, err = minioClient.FPutObject("runs", minioKey, fileName, "application/gzip")
+	_, err = minioClient.FPutObject("runs", minioKey, fileName, fileType)
 	if err != nil {
 	    fmt.Println(err)
-	    return
+	    return err
 		}
+	return nil
 	}
 
 func hashKey(key string) string {

--- a/minio/go/src/cloud/benchflow/commons/minio/minio.go
+++ b/minio/go/src/cloud/benchflow/commons/minio/minio.go
@@ -14,6 +14,8 @@ import (
 
 const numOfHashCharacters int = 4
 
+/*
+// We keep thos function in case the API fails because of a Minio update
 func callMinioClient(fileName string, minioHost string, minioKey string) {
 		//TODO: change, we are using sudo to elevate the priviledge in the container, but it is not nice
 		//NOTE: it seems that the commands that are not in PATH, should be launched using sh -c
@@ -30,6 +32,11 @@ func callMinioClient(fileName string, minioHost string, minioKey string) {
 		}
 		fmt.Println("Result: " + out.String())
 }
+*/
+
+func sendGzipToMinio(fileName string, minioHost string, minioKey string, accessKey string, secretAccessKey string) {
+	sendToMinio(fileName, minioHost, minioKey, accessKey, secretAccessKey, "application/gzip")
+	}
 
 func sendToMinio(fileName string, minioHost string, minioKey string, accessKey string, secretAccessKey string, fileType string) error {
 	minioClient, err := minio.New(minioHost, accessKey, secretAccessKey, true)


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/benchflow/commons/pull/10%23issuecomment-221923683%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23issuecomment-221927226%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23issuecomment-222471085%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23issuecomment-222551478%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23issuecomment-222551509%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23issuecomment-222551528%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64777440%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64781756%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64782020%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64782090%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64786200%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64878215%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64878312%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64881510%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64881590%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r65104402%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r65104415%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r65104416%22%2C%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r65104460%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benchflow/commons/pull/10%23issuecomment-221923683%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40Cerfoglg%20map%20the%20involved%20issues%22%2C%20%22created_at%22%3A%20%222016-05-26T16%3A30%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40VincenzoFerme%20%5Cr%5Cn%5Cr%5CnRegarding%20issues%20benchflow/collectors%2358%20%2C%20benchflow/collectors%2365%20%2C%20benchflow/collectors%2346%22%2C%20%22created_at%22%3A%20%222016-05-26T16%3A43%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8819678%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Cerfoglg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40VincenzoFerme%20Should%20be%20good%20now%22%2C%20%22created_at%22%3A%20%222016-05-30T11%3A19%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8819678%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Cerfoglg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40Cerfoglg%20the%20references%20issues%20are%20in%20the%20collectors%20repository.%20Reference%20to%20then%20when%20you%20update%20the%20collectors%2C%20so%20we%20can%20declare%20them%20fixed.%22%2C%20%22created_at%22%3A%20%222016-05-30T20%3A34%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-05-30T20%3A34%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-05-30T20%3A34%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ca5c866bb0f8bf982153d86459819cc432dd0bec%20kafka/go/src/cloud/benchflow/commons/kafka/kafka.go%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64777440%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20port%20should%20also%20be%20a%20parameter%22%2C%20%22created_at%22%3A%20%222016-05-26T16%3A29%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-05-26T17%3A29%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20kafka/go/src/cloud/benchflow/commons/kafka/kafka.go%3AL10-31%22%7D%2C%20%22Pull%208fa73b4ae669daa76962914b3656611db09c8bb2%20minio/go/src/cloud/benchflow/commons/minio/minio.go%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64781756%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20set%20%60application/gzip%60%2C%20then%20the%20function%27s%20name%20should%20refer%20to%20gzip%20and%20call%20another%20generic%20function%20%60sendToMinio%60%20accepting%20the%20MIME%20type%20as%20parameter%22%2C%20%22created_at%22%3A%20%222016-05-26T16%3A59%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40VincenzoFerme%20I%27ll%20just%20take%20the%20object%20type%20as%20argument%20directly.%20The%20caller%20should%20know%20what%20type%20the%20file%20is.%22%2C%20%22created_at%22%3A%20%222016-05-27T09%3A14%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8819678%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Cerfoglg%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20can%20abstract%20it%20away%20for%20the%20caller%2C%20since%20most%20of%20the%20calls%20are%20JSON.%22%2C%20%22created_at%22%3A%20%222016-05-27T09%3A42%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-05-30T20%3A31%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20minio/go/src/cloud/benchflow/commons/minio/minio.go%3AL31-60%22%7D%2C%20%22Pull%208fa73b4ae669daa76962914b3656611db09c8bb2%20minio/go/src/cloud/benchflow/commons/minio/minio.go%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64782090%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20might%20want%20to%20return%20the%20error%20to%20the%20caller%2C%20so%20it%20can%20decide%20what%20to%20do%22%2C%20%22created_at%22%3A%20%222016-05-26T17%3A01%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-05-30T20%3A30%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-05-30T20%3A31%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20minio/go/src/cloud/benchflow/commons/minio/minio.go%3AL31-60%22%7D%2C%20%22Pull%208fa73b4ae669daa76962914b3656611db09c8bb2%20minio/go/src/cloud/benchflow/commons/minio/minio.go%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benchflow/commons/pull/10%23discussion_r64782020%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20do%20you%20still%20have%20this%20function%20since%20it%20is%20empty%3F%22%2C%20%22created_at%22%3A%20%222016-05-26T17%3A01%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40VincenzoFerme%20Just%20in%20case%20the%20API%20stops%20working%20properly%20again%2C%20we%20should%20keep%20the%20minio%20client%20call%20as%20well%22%2C%20%22created_at%22%3A%20%222016-05-27T09%3A15%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8819678%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Cerfoglg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Comment%20it%20out%20then%2C%20and%20add%20a%20comment%20explain%20this%20choice.%22%2C%20%22created_at%22%3A%20%222016-05-27T09%3A43%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-05-30T20%3A31%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20minio/go/src/cloud/benchflow/commons/minio/minio.go%3AL8-19%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/VincenzoFerme%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/VincenzoFerme'><img src='https://avatars.githubusercontent.com/u/7163641?v=3' width=34 height=34></a>
- [x] <a href='#crh-comment-Pull ca5c866bb0f8bf982153d86459819cc432dd0bec kafka/go/src/cloud/benchflow/commons/kafka/kafka.go 25'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benchflow/commons/pull/10#discussion_r64777440'>File: kafka/go/src/cloud/benchflow/commons/kafka/kafka.go:L10-31</a></b>
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> The port should also be a parameter
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benchflow/commons/pull/10#issuecomment-221923683'>General Comment</a></b>
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> @Cerfoglg map the involved issues
- <a href='https://github.com/Cerfoglg'><img border=0 src='https://avatars.githubusercontent.com/u/8819678?v=3' height=16 width=16'></a> @VincenzoFerme
  Regarding issues benchflow/collectors#58 , benchflow/collectors#65 , benchflow/collectors#46
- <a href='https://github.com/Cerfoglg'><img border=0 src='https://avatars.githubusercontent.com/u/8819678?v=3' height=16 width=16'></a> @VincenzoFerme Should be good now
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> @Cerfoglg the references issues are in the collectors repository. Reference to then when you update the collectors, so we can declare them fixed.
- [x] <a href='#crh-comment-Pull 8fa73b4ae669daa76962914b3656611db09c8bb2 minio/go/src/cloud/benchflow/commons/minio/minio.go 52'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benchflow/commons/pull/10#discussion_r64781756'>File: minio/go/src/cloud/benchflow/commons/minio/minio.go:L31-60</a></b>
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> You set `application/gzip`, then the function's name should refer to gzip and call another generic function `sendToMinio` accepting the MIME type as parameter
- <a href='https://github.com/Cerfoglg'><img border=0 src='https://avatars.githubusercontent.com/u/8819678?v=3' height=16 width=16'></a> @VincenzoFerme I'll just take the object type as argument directly. The caller should know what type the file is.
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> You can abstract it away for the caller, since most of the calls are JSON.
- [x] <a href='#crh-comment-Pull 8fa73b4ae669daa76962914b3656611db09c8bb2 minio/go/src/cloud/benchflow/commons/minio/minio.go 35'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benchflow/commons/pull/10#discussion_r64782020'>File: minio/go/src/cloud/benchflow/commons/minio/minio.go:L8-19</a></b>
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> Why do you still have this function since it is empty?
- <a href='https://github.com/Cerfoglg'><img border=0 src='https://avatars.githubusercontent.com/u/8819678?v=3' height=16 width=16'></a> @VincenzoFerme Just in case the API stops working properly again, we should keep the minio client call as well
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> Comment it out then, and add a comment explain this choice.
- [x] <a href='#crh-comment-Pull 8fa73b4ae669daa76962914b3656611db09c8bb2 minio/go/src/cloud/benchflow/commons/minio/minio.go 46'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benchflow/commons/pull/10#discussion_r64782090'>File: minio/go/src/cloud/benchflow/commons/minio/minio.go:L31-60</a></b>
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> You might want to return the error to the caller, so it can decide what to do

<a href='https://www.codereviewhub.com/benchflow/commons/pull/10?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/benchflow/commons/pull/10?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/benchflow/commons/pull/10?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/commons/pull/10'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
