### PR TITLE
Fixes broken CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build_java:
 
 build_release_java:
 	# Install keyname-hash-generator so that can be used as dependency for the minio build
-	JAVA_HOME=$(JAVA_HOME) mvn package
+	JAVA_HOME=$(JAVA_HOME) mvn package -pl minio/java -am install
 	# cd keyname-hash-generator/java/ && \
 	# JAVA_HOME=$(JAVA_HOME) mvn package && \
 	# JAVA_HOME=$(JAVA_HOME) mvn install

--- a/keyname-hash-generator/java/pom.xml
+++ b/keyname-hash-generator/java/pom.xml
@@ -1,19 +1,22 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>cloud.benchflow.commons</groupId>
   <artifactId>keyname-hash-generator</artifactId>
-  <version>0.0.1</version>
-  <name>keyname-hash-generator</name>
+  <version>0.1.0</version>
+  <name>benchflow-keyname-hash-generator</name>
+
   <properties>
     <project.name>benchflow-keyname-hash-generator</project.name>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
   </properties>
+
   <build>
-    <sourceDirectory>src</sourceDirectory>
-    <finalName>benchflow-${project.name}</finalName>
+
     <plugins>
+
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
@@ -22,6 +25,23 @@
           <target>${java.version}</target>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <finalName>${project.name}</finalName>
+          <archive>
+            <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+
     </plugins>
+
   </build>
+
 </project>

--- a/minio/java/pom.xml
+++ b/minio/java/pom.xml
@@ -66,6 +66,8 @@
                 </configuration>
             </plugin>
 
+          </plugins>
+          
     </build>
 
 </project>

--- a/minio/java/pom.xml
+++ b/minio/java/pom.xml
@@ -34,13 +34,14 @@
         <dependency>
             <groupId>cloud.benchflow.commons</groupId>
             <artifactId>keyname-hash-generator</artifactId>
-            <version>0.0.1</version>
+            <version>0.1.0</version>
         </dependency>
 
     </dependencies>
 
     <build>
         <plugins>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -49,28 +50,6 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <id>generateSources</id>
-                        <phase>validate</phase>
-                        <configuration>
-                            <tasks>
-                                <exec executable="/bin/bash">
-                                    <arg value="./bin/get-dependencies.sh" />
-                                </exec>
-                            </tasks>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>
@@ -86,28 +65,7 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
-                <executions>
-                    <execution>
-                        <id>install-hash-generator</id>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                        <phase>validate</phase>
-                        <configuration>
-                            <groupId>cloud.benchflow.commons</groupId>
-                            <artifactId>keyname-hash-generator</artifactId>
-                            <version>0.0.1</version>
-                            <packaging>jar</packaging>
-                            <file>${project.basedir}/lib/benchflow-keyname-hash-generator.jar</file>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+
     </build>
 
 </project>


### PR DESCRIPTION
- Uniforms the POM of `keyname-hash-generator` to the pom of `minio-client`;
- Fixes CI.
  <a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
  <a href='https://www.codereviewhub.com/benchflow/commons/pull/18?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/commons/pull/18'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
  <a href='#crh-end'></a>
